### PR TITLE
Added Documentation navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,9 @@
               <a href="https://medium.com/zeppelin-blog" target="_blank">Blog</a>
             </li>
             <li>
+              <a href="http://zeppelin-solidity.readthedocs.io/en/latest/index.html" target="_blank">Documentation</a>
+            </li>
+            <li>
               <a href="https://smartcontractsolutions.com/security-audits" target="_blank">Security audits</a>
             </li>
             <li>


### PR DESCRIPTION
I think the page should have the Documentation navigation link as other frameworks do, it links to readthedocs.io.

<img width="1383" alt="screen shot 2017-06-26 at 1 52 08 am" src="https://user-images.githubusercontent.com/1851436/27525169-e2157c3c-5a11-11e7-8183-4aa1b0c772eb.png">
